### PR TITLE
Add Azure Static Web Apps deployment configuration

### DIFF
--- a/.github/workflows/azure-static-web-app.yml
+++ b/.github/workflows/azure-static-web-app.yml
@@ -1,0 +1,27 @@
+name: Deploy to Azure Static Web Apps
+
+on:
+  push:
+    branches:
+      - work
+  workflow_dispatch:
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          app_location: '/'
+          output_location: 'dist'

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ tmp/
 !tailwind.config.js
 !postcss.config.js
 !docker-compose.yml
+!staticwebapp.config.json
 
 # Test output directories
 test-results/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ docker build -t azure-firewall-analyzer .
 docker run -p 3000:80 azure-firewall-analyzer
 ```
 
+### Option 4: Azure Static Web Apps (Free Tier)
+Deploy the built static files using [Azure Static Web Apps](https://azure.microsoft.com/products/app-service/static) for a cost-free hosting option.
+
+1. Fork this repository to your own GitHub account.
+2. Create a **Static Web App** in the Azure portal and choose the Free plan.
+3. During setup, set the build output folder to `dist` and provide the deployment token as the secret `AZURE_STATIC_WEB_APPS_API_TOKEN` in your GitHub repository.
+4. Push changes to the `work` branch. The included GitHub workflow will build the app and deploy the `dist` folder automatically.
+
+> The workflow file is located at `.github/workflows/azure-static-web-app.yml` and uses the `staticwebapp.config.json` file to support client-side routing.
+
 ## 📋 How to Use
 
 ### 1. Export Your Azure Firewall Policy

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/assets/*.{js,css}"]
+  }
+}


### PR DESCRIPTION
## Summary
- add GitHub workflow to deploy build output to Azure Static Web Apps
- document free deployment option and config for client-side routing
- track staticwebapp.config.json in gitignore exceptions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 45 errors, 2 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c0f5d8988331808e74c5ddcc7166